### PR TITLE
Rename secrets to new `trust-domain-scopes` format

### DIFF
--- a/reps/templates/python/cookiecutter.json
+++ b/reps/templates/python/cookiecutter.json
@@ -14,7 +14,7 @@
     "trust_domain": "mozilla",
     "trust_project": "{{cookiecutter.__github_project}}",
     "level": "1",
-    "__secrets_path": "project/{{cookiecutter.trust_domain}}/{{cookiecutter.trust_project}}/level-{{cookiecutter.level}}/ci",
+    "__codecov_secrets_path": "project/{{cookiecutter.trust_domain}}/{{cookiecutter.trust_project}}/level-any/codecov",
     "_copy_without_render": [
         ".github/workflows/codeql-analysis.yml"
     ]

--- a/reps/templates/python/cookiecutter.json
+++ b/reps/templates/python/cookiecutter.json
@@ -14,7 +14,7 @@
     "trust_domain": "mozilla",
     "trust_project": "{{cookiecutter.__github_project}}",
     "level": "1",
-    "__secrets_path": "project/releng/{{cookiecutter.trust_domain}}/{{cookiecutter.trust_project}}/build/level-{{cookiecutter.level}}/ci",
+    "__secrets_path": "project/{{cookiecutter.trust_domain}}/{{cookiecutter.trust_project}}/level-{{cookiecutter.level}}/ci",
     "_copy_without_render": [
         ".github/workflows/codeql-analysis.yml"
     ]

--- a/reps/templates/python/{{cookiecutter.__project_slug}}/taskcluster/ci/codecov/kind.yml
+++ b/reps/templates/python/{{cookiecutter.__project_slug}}/taskcluster/ci/codecov/kind.yml
@@ -22,7 +22,7 @@ tasks:
             env:
                 MOZ_FETCHES_DIR: /builds/worker/fetches
         scopes:
-            - secrets:get:{{cookiecutter.__secrets_path}}
+            - secrets:get:{{cookiecutter.__codecov_secrets_path}}
         dependencies:
             test: test-unit
         fetches:

--- a/reps/templates/python/{{cookiecutter.__project_slug}}/taskcluster/scripts/codecov-upload.py
+++ b/reps/templates/python/{{cookiecutter.__project_slug}}/taskcluster/scripts/codecov-upload.py
@@ -17,7 +17,7 @@ def fetch_secret(secret_name):
     return r.json()["secret"]
 
 
-token = fetch_secret("{{cookiecutter.__secrets_path}}")["codecov_api_token"]
+token = fetch_secret("{{cookiecutter.__codecov_secrets_path}}")["token"]
 uploader = FETCHES_DIR / "codecov"
 uploader.chmod(uploader.stat().st_mode | stat.S_IEXEC)
 subprocess.run(

--- a/taskcluster/ci/codecov/kind.yml
+++ b/taskcluster/ci/codecov/kind.yml
@@ -22,7 +22,7 @@ tasks:
             env:
                 MOZ_FETCHES_DIR: /builds/worker/fetches
         scopes:
-            - secrets:get:project/mozilla/reps/level-1/ci
+            - secrets:get:project/mozilla/reps/level-any/codecov
         dependencies:
             test: test-unit
         fetches:

--- a/taskcluster/ci/codecov/kind.yml
+++ b/taskcluster/ci/codecov/kind.yml
@@ -22,7 +22,7 @@ tasks:
             env:
                 MOZ_FETCHES_DIR: /builds/worker/fetches
         scopes:
-            - secrets:get:project/releng/mozilla/reps/build/level-1/ci
+            - secrets:get:project/mozilla/reps/level-1/ci
         dependencies:
             test: test-unit
         fetches:

--- a/taskcluster/scripts/codecov-upload.py
+++ b/taskcluster/scripts/codecov-upload.py
@@ -17,7 +17,7 @@ def fetch_secret(secret_name):
     return r.json()["secret"]
 
 
-token = fetch_secret("project/mozilla/reps/level-1/ci")["codecov_api_token"]
+token = fetch_secret("project/mozilla/reps/level-any/codecov")["token"]
 uploader = FETCHES_DIR / "codecov"
 uploader.chmod(uploader.stat().st_mode | stat.S_IEXEC)
 subprocess.run(

--- a/taskcluster/scripts/codecov-upload.py
+++ b/taskcluster/scripts/codecov-upload.py
@@ -17,9 +17,7 @@ def fetch_secret(secret_name):
     return r.json()["secret"]
 
 
-token = fetch_secret("project/releng/mozilla/reps/build/level-1/ci")[
-    "codecov_api_token"
-]
+token = fetch_secret("project/mozilla/reps/level-1/ci")["codecov_api_token"]
 uploader = FETCHES_DIR / "codecov"
 uploader.chmod(uploader.stat().st_mode | stat.S_IEXEC)
 subprocess.run(


### PR DESCRIPTION
This adjusts both the codecov secret that reps itself uses, as well as the template.