### PR TITLE
fix: ensure 'package_name' always uses underscores

### DIFF
--- a/reps/templates/python/cookiecutter.json
+++ b/reps/templates/python/cookiecutter.json
@@ -1,7 +1,7 @@
 {
     "project_name": "My Project",
     "__project_slug": "{{cookiecutter.project_name|lower|replace(' ', '-')}}",
-    "__package_name": "{{cookiecutter.project_name|lower|replace(' ', '_')}}",
+    "__package_name": "{{cookiecutter.project_name|lower|replace(' ', '_')|replace('-', '_')}}",
     "short_description": "",
     "author": "Mozilla Release Engineering <release@mozilla.com>",
     "github_slug": "mozilla-releng/{{cookiecutter.__project_slug}}",


### PR DESCRIPTION
Without this fix, entering 'my-package' as the project name results in a directory called 'src/my-package', which is not importable in Python.

Also adds a test.