### PR TITLE
fix(python): typo in .pre-commit-config.yaml

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 ---
 ci:
     autofix_commit_msg: 'style: pre-commit.ci auto fixes [...]'
-    autoupdate_comit_msg: 'chore: pre-commit autoupdate'
+    autoupdate_commit_msg: 'chore: pre-commit autoupdate'
 repos:
     - hooks:
           - id: trailing-whitespace

--- a/reps/templates/base/{{cookiecutter.__project_slug}}/.pre-commit-config.yaml
+++ b/reps/templates/base/{{cookiecutter.__project_slug}}/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 ---
 ci:
   autofix_commit_msg: "style: pre-commit.ci auto fixes [...]"
-  autoupdate_comit_msg: "chore: pre-commit autoupdate"
+  autoupdate_commit_msg: "chore: pre-commit autoupdate"
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.4.0


### PR DESCRIPTION
This was causing the wrong pre-commit commit message to be used.