### PR TITLE
fix(python): set pre-commit autoupdate schedule to monthly

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,6 +2,7 @@
 ci:
     autofix_commit_msg: 'style: pre-commit.ci auto fixes [...]'
     autoupdate_commit_msg: 'chore: pre-commit autoupdate'
+    autoupdate_schedule: monthly
 repos:
     - hooks:
           - id: trailing-whitespace

--- a/reps/templates/base/{{cookiecutter.__project_slug}}/.pre-commit-config.yaml
+++ b/reps/templates/base/{{cookiecutter.__project_slug}}/.pre-commit-config.yaml
@@ -2,6 +2,7 @@
 ci:
   autofix_commit_msg: "style: pre-commit.ci auto fixes [...]"
   autoupdate_commit_msg: "chore: pre-commit autoupdate"
+  autoupdate_schedule: monthly
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.4.0


### PR DESCRIPTION
I find weekly updates create a lot of busy work, especially with many repos using the same cadence. Monthly seems like a nicer default.