### PR TITLE
Force the lock file maintainance job to rebase when creating PRs

### DIFF
--- a/renovate-preset.json5
+++ b/renovate-preset.json5
@@ -83,7 +83,8 @@
   "lockFileMaintenance": {
     "enabled": true,
     "branchTopic": "lock-file-maintenance-{{manager}}",
-    "commitMessageExtra": "({{manager}})"
+    "commitMessageExtra": "({{manager}})",
+    "rebaseWhen": "behind-base-branch"
   },
   // customManagers is where we specify dependency updates for files that renovate doesn't
   // know how to parse out-of-box


### PR DESCRIPTION
Right now when it creates those lockfiles PRs, it keeps the state it's already in as the base branch and ends up creating useless PRs on which we have to manually click the "rebase/retry" button to get the right outcome. I'm hoping that telling it to rebase when it's behind base will automatically do that. I'm 50% sure that it won't trigger on every single push even if the PR stays open because AFAIU, renovate only runs things during their given window (which is "monday before 4am" for lockfiles, although we should probably change that to match the rest).