### PR TITLE
chore(renovate): handle 'isBreaking = undefined' properly

### DIFF
--- a/renovate-preset.json5
+++ b/renovate-preset.json5
@@ -43,14 +43,14 @@
     {
       "matchManagers": ["pep621"],
       "matchUpdateTypes": ["patch", "minor"],
-      "matchJsonata": ["isBreaking != true"],
+      "matchJsonata": ["$not(isBreaking = true)"],
       "groupName": "python dependencies"
     },
     // group all non-breaking JS dependencies together
     {
       "matchManagers": ["npm"],
       "matchUpdateTypes": ["patch", "minor"],
-      "matchJsonata": ["isBreaking != true"],
+      "matchJsonata": ["$not(isBreaking = true)"],
       "groupName": "js dependencies"
     },
     // group all non-breaking docker-related files together, as much as possible anyways
@@ -61,14 +61,14 @@
     {
       "matchManagers": ["dockerfile", "docker-compose"],
       "matchUpdateTypes": ["digest", "patch", "minor"],
-      "matchJsonata": ["isBreaking != true"],
+      "matchJsonata": ["$not(isBreaking = true)"],
       "groupName": "docker dependencies"
     },
     // group all non-breaking github action bumps together
     {
       "matchManagers": ["github-actions"],
       "matchUpdateTypes": ["digest", "patch", "minor"],
-      "matchJsonata": ["isBreaking != true"],
+      "matchJsonata": ["$not(isBreaking = true)"],
       "groupName": "github actions"
     },
     {


### PR DESCRIPTION
According to the renovate config we were supposed to be grouping digest, patch and minor docker image updates together into the same PR. But I noticed this wasn't working for digests.

I believe the issue is the `matchJsonata` line that has `isBreaking != true`. It appears that for digest updates, `isBreaking` is set to `undefined`.

Using https://try.jsonata.org/, I confirmed that:

> undefined != true
false

> $not(undefined = true)
true

So this should make sure that `digest` updates match the group. I also updated other places we were using `isBreaking != true` just in case it can ever be undefined in those cases as well.