### PR TITLE
fix(bug 2043228): allow renovate PRs to be created at any hour

### DIFF
--- a/renovate-preset.json5
+++ b/renovate-preset.json5
@@ -20,8 +20,13 @@
     ":enablePreCommit"
   ],
   "schedule": [
-    // schedule updates at 0200 UTC on the first of the month
-    "* 2 1 * *"
+    // schedule updates on the first of the month
+    // we explicitly avoid specifying an hour here because we can't control
+    // when the renovate bot runs. if it runs at an hour outside of our
+    // specified schedule (eg: if we say only at 5am), no PRs will be created
+    // see https://docs.renovatebot.com/key-concepts/scheduling/#global-schedule-vs-specific-schedule
+    // for more
+    "* * 1 * *"
   ],
   // this is the default, but let's be explicit about it
   "timezone": "UTC",
@@ -69,14 +74,10 @@
       "matchUpdateTypes": ["digest", "patch", "minor"],
       "matchJsonata": ["$not(isBreaking = true)"],
       "groupName": "github actions",
-      // Once a month is enough
-      "schedule": ["* 2 1 * *"]
     },
     {
       "matchManagers": ["pre-commit"],
       "groupName": "pre-commit hooks",
-      // Once a month is enough
-      "schedule": ["* 2 1 * *"]
     },
   ],
   // Refresh lock files to update dependencies that aren't directly pinned in


### PR DESCRIPTION
From [the documentation](https://docs.renovatebot.com/key-concepts/scheduling/#global-schedule-vs-specific-schedule)

> Renovate can only update a dependency if both of these conditions are true:
>
> * The Renovate program is running (on your hardware, or on Mend's hardware)
> * The schedule set in the Renovate config file(s) allows Renovate to look for updates for that dependency

The documentation additionally describes that Mend controls when the Renovate program is running.

With this in mind, I believe the recent changes to restrict Renovate to only running at 2am UTC have resulted in fewer PRs being created. Now that we've made the change to restrict to one day a month, having them opened at any hour shouldn't be a big deal.