### PR TITLE
fix: renovate preset syntax

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "local:renovate-preset"
+    "local>mozilla-releng/reps:renovate-preset"
   ],
   "customManagers": [
     {


### PR DESCRIPTION
The docs are thin on how to use `local`, but based on what I see https://docs.renovatebot.com/config-presets and looking at some examples in the wild, this looks valid.

At the moment we're getting these errors when renovate runs:
```
These problems occurred while renovating this repository.

    Reason: Cannot find preset's package (local:renovate-preset)

    Message: undefined
```