### PR TITLE
fix: change lockFileMaintenance schedule to match main schedule

### DIFF
--- a/renovate-preset.json5
+++ b/renovate-preset.json5
@@ -86,7 +86,12 @@
     "enabled": true,
     "branchTopic": "lock-file-maintenance-{{manager}}",
     "commitMessageExtra": "({{manager}})",
-    "rebaseWhen": "behind-base-branch"
+    "rebaseWhen": "behind-base-branch",
+    "schedule": [
+      // should be kept in sync with the main schedule
+      // (lockFileMaintenance doesn't obey that...it defaults to "before 4am on monday")
+      "* * 1 * *"
+    ]
   },
   // customManagers is where we specify dependency updates for files that renovate doesn't
   // know how to parse out-of-box


### PR DESCRIPTION
Per [the source code](https://github.com/renovatebot/renovate/blob/a5679746d7a6ecdaa87f8023088ce6df974c622d/lib/config/options/index.ts#L2565), lock file maintenance follows its own schedule.