### PR TITLE
fix: renovate.json configuration (round 2)

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "local>mozilla-releng/reps:renovate-preset"
+    "github>mozilla-releng/reps:renovate-preset.json5"
   ],
   "customManagers": [
     {


### PR DESCRIPTION
#94 fixed the configuration syntax error, but we're still getting:
```
Reason: Cannot find preset's package (local>mozilla-releng/reps:renovate-preset)
```

This change moves us to the same syntax we use for other repos, so presumably it will work?