### PR TITLE
fix: use base repo when finding project name for pull requests

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -31,7 +31,7 @@ tasks:
           project:
               $switch:
                   'tasks_for == "github-push"': '${event.repository.name}'
-                  'tasks_for[:19] == "github-pull-request"': '${event.pull_request.head.repo.name}'
+                  'tasks_for[:19] == "github-pull-request"': '${event.pull_request.base.repo.name}'
                   'tasks_for in ["cron", "action"]': '${repository.project}'
           head_branch:
               $switch:

--- a/template/.taskcluster.yml.tmpl
+++ b/template/.taskcluster.yml.tmpl
@@ -32,7 +32,7 @@ tasks:
           project:
               $switch:
                   'tasks_for == "github-push"': '${event.repository.name}'
-                  'tasks_for[:19] == "github-pull-request"': '${event.pull_request.head.repo.name}'
+                  'tasks_for[:19] == "github-pull-request"': '${event.pull_request.base.repo.name}'
                   'tasks_for in ["cron", "action"]': '${repository.project}'
           head_branch:
               $switch:


### PR DESCRIPTION
We grant certain scopes (like to caches) using the base repo name. We need to make sure we do the same in `.taskcluster.yml` to make such things works. (Same thing goes for index routes, env vars, etc.)